### PR TITLE
Optimisation of propertry exposes

### DIFF
--- a/GeometRi.Benchmarks/Program.cs
+++ b/GeometRi.Benchmarks/Program.cs
@@ -5,7 +5,7 @@ using GeometRi;
 
 namespace GeometRi.Benchmarks
 {
-    class Program
+    class IntersectionBenchmark
     {
         static void Main(string[] args)
         {

--- a/GeometRi/AABB.cs
+++ b/GeometRi/AABB.cs
@@ -509,7 +509,7 @@ namespace GeometRi
         /// </summary>
         public object IntersectionWith(Segment3d s)
         {
-            return _line_intersection(s.ToLine, 0.0, s.Length);
+            return _line_intersection(s.Line, 0.0, s.Length);
         }
 
         /// <summary>

--- a/GeometRi/AABB.cs
+++ b/GeometRi/AABB.cs
@@ -658,31 +658,31 @@ namespace GeometRi
             Point3d Pmin = this.P1.ConvertTo(local_CS);
             Point3d Pmax = this.P7.ConvertTo(local_CS);
 
-            l = new Line3d(l._point.ConvertTo(local_CS), l._dir.ConvertTo(local_CS).Normalized);
+            l = new Line3d(l.Point.ConvertTo(local_CS), l.Direction.ConvertTo(local_CS).Normalized);
 
             double tmin, tmax, tymin, tymax, tzmin, tzmax;
-            double divx = 1 / l._dir.X;
+            double divx = 1 / l.Direction.X;
             if (divx >= 0)
             {
-                tmin = (Pmin.X - l._point.X) * divx;
-                tmax = (Pmax.X - l._point.X) * divx;
+                tmin = (Pmin.X - l.Point.X) * divx;
+                tmax = (Pmax.X - l.Point.X) * divx;
             }
             else
             {
-                tmin = (Pmax.X - l._point.X) * divx;
-                tmax = (Pmin.X - l._point.X) * divx;
+                tmin = (Pmax.X - l.Point.X) * divx;
+                tmax = (Pmin.X - l.Point.X) * divx;
             }
 
-            double divy = 1 / l._dir.Y;
+            double divy = 1 / l.Direction.Y;
             if (divy >= 0)
             {
-                tymin = (Pmin.Y - l._point.Y) * divy;
-                tymax = (Pmax.Y - l._point.Y) * divy;
+                tymin = (Pmin.Y - l.Point.Y) * divy;
+                tymax = (Pmax.Y - l.Point.Y) * divy;
             }
             else
             {
-                tymin = (Pmax.Y - l._point.Y) * divy;
-                tymax = (Pmin.Y - l._point.Y) * divy;
+                tymin = (Pmax.Y - l.Point.Y) * divy;
+                tymax = (Pmin.Y - l.Point.Y) * divy;
             }
 
             if (GeometRi3D.Greater(tmin, tymax) || GeometRi3D.Greater(tymin, tmax))
@@ -692,16 +692,16 @@ namespace GeometRi
             if (GeometRi3D.Smaller(tymax, tmax))
                 tmax = tymax;
 
-            double divz = 1 / l._dir.Z;
+            double divz = 1 / l.Direction.Z;
             if (divz >= 0)
             {
-                tzmin = (Pmin.Z - l._point.Z) * divz;
-                tzmax = (Pmax.Z - l._point.Z) * divz;
+                tzmin = (Pmin.Z - l.Point.Z) * divz;
+                tzmax = (Pmax.Z - l.Point.Z) * divz;
             }
             else
             {
-                tzmin = (Pmax.Z - l._point.Z) * divz;
-                tzmax = (Pmin.Z - l._point.Z) * divz;
+                tzmin = (Pmax.Z - l.Point.Z) * divz;
+                tzmax = (Pmin.Z - l.Point.Z) * divz;
             }
 
             if (GeometRi3D.Greater(tmin, tzmax) || GeometRi3D.Greater(tzmin, tmax))
@@ -725,11 +725,11 @@ namespace GeometRi
 
             if (GeometRi3D.AlmostEqual(tmin, tmax))
             {
-                return l._point.Translate(tmin * l._dir);
+                return l.Point.Translate(tmin * l.Direction);
             }
             else
             {
-                return new Segment3d(l._point.Translate(tmin * l._dir), l._point.Translate(tmax * l._dir));
+                return new Segment3d(l.Point.Translate(tmin * l.Direction), l.Point.Translate(tmax * l.Direction));
             }
         }
         #endregion

--- a/GeometRi/AbstractClass.cs
+++ b/GeometRi/AbstractClass.cs
@@ -12,4 +12,8 @@ namespace GeometRi
     {
         abstract internal int _PointLocation(Point3d p);
     }
+    abstract public class PlanarFiniteObject : FiniteObject
+    {
+        abstract internal Plane3d Plane { get; }
+    }
 }

--- a/GeometRi/AbstractClass.cs
+++ b/GeometRi/AbstractClass.cs
@@ -16,4 +16,10 @@ namespace GeometRi
     {
         abstract internal Plane3d Plane { get; }
     }
+    abstract public class LinearFiniteObject : FiniteObject
+    {
+        abstract internal Line3d Line { get; }
+        abstract internal Vector3d Vector { get; }
+        abstract internal Ray3d Ray { get; }
+    }
 }

--- a/GeometRi/Box3d.cs
+++ b/GeometRi/Box3d.cs
@@ -665,31 +665,31 @@ namespace GeometRi
             Point3d Pmin = this.P1.ConvertTo(local_CS);
             Point3d Pmax = this.P7.ConvertTo(local_CS);
 
-            l = new Line3d(l._point.ConvertTo(local_CS), l._dir.ConvertTo(local_CS).Normalized);
+            l = new Line3d(l.Point.ConvertTo(local_CS), l.Direction.ConvertTo(local_CS).Normalized);
 
             double tmin, tmax, tymin, tymax, tzmin, tzmax;
-            double divx = 1 / l._dir.X;
+            double divx = 1 / l.Direction.X;
             if (divx >= 0)
             {
-                tmin = (Pmin.X - l._point.X) * divx;
-                tmax = (Pmax.X - l._point.X) * divx;
+                tmin = (Pmin.X - l.Point.X) * divx;
+                tmax = (Pmax.X - l.Point.X) * divx;
             }
             else
             {
-                tmin = (Pmax.X - l._point.X) * divx;
-                tmax = (Pmin.X - l._point.X) * divx;
+                tmin = (Pmax.X - l.Point.X) * divx;
+                tmax = (Pmin.X - l.Point.X) * divx;
             }
 
-            double divy = 1 / l._dir.Y;
+            double divy = 1 / l.Direction.Y;
             if (divy >= 0)
             {
-                tymin = (Pmin.Y - l._point.Y) * divy;
-                tymax = (Pmax.Y - l._point.Y) * divy;
+                tymin = (Pmin.Y - l.Point.Y) * divy;
+                tymax = (Pmax.Y - l.Point.Y) * divy;
             }
             else
             {
-                tymin = (Pmax.Y - l._point.Y) * divy;
-                tymax = (Pmin.Y - l._point.Y) * divy;
+                tymin = (Pmax.Y - l.Point.Y) * divy;
+                tymax = (Pmin.Y - l.Point.Y) * divy;
             }
 
             if (GeometRi3D.Greater(tmin, tymax) || GeometRi3D.Greater(tymin, tmax))
@@ -699,16 +699,16 @@ namespace GeometRi
             if (GeometRi3D.Smaller(tymax, tmax))
                 tmax = tymax;
 
-            double divz = 1 / l._dir.Z;
+            double divz = 1 / l.Direction.Z;
             if (divz >= 0)
             {
-                tzmin = (Pmin.Z - l._point.Z) * divz;
-                tzmax = (Pmax.Z - l._point.Z) * divz;
+                tzmin = (Pmin.Z - l.Point.Z) * divz;
+                tzmax = (Pmax.Z - l.Point.Z) * divz;
             }
             else
             {
-                tzmin = (Pmax.Z - l._point.Z) * divz;
-                tzmax = (Pmin.Z - l._point.Z) * divz;
+                tzmin = (Pmax.Z - l.Point.Z) * divz;
+                tzmax = (Pmin.Z - l.Point.Z) * divz;
             }
 
             if (GeometRi3D.Greater(tmin, tzmax) || GeometRi3D.Greater(tzmin, tmax))
@@ -732,11 +732,11 @@ namespace GeometRi
 
             if (GeometRi3D.AlmostEqual(tmin, tmax))
             {
-                return l._point.Translate(tmin * l._dir);
+                return l.Point.Translate(tmin * l.Direction);
             }
             else
             {
-                return new Segment3d(l._point.Translate(tmin * l._dir), l._point.Translate(tmax * l._dir));
+                return new Segment3d(l.Point.Translate(tmin * l.Direction), l.Point.Translate(tmax * l.Direction));
             }
         }
 #endregion

--- a/GeometRi/Box3d.cs
+++ b/GeometRi/Box3d.cs
@@ -604,7 +604,7 @@ namespace GeometRi
         /// </summary>
         public object IntersectionWith(Segment3d s)
         {
-            return _line_intersection(s.ToLine, 0.0, s.Length);
+            return _line_intersection(s.Line, 0.0, s.Length);
         }
 
         /// <summary>

--- a/GeometRi/Circle3D.cs
+++ b/GeometRi/Circle3D.cs
@@ -1421,8 +1421,8 @@ namespace GeometRi
                 Plane3d plane_this = new Plane3d(this._point, this._normal);
 
                 Line3d l = (Line3d)plane_this.IntersectionWith(new Plane3d(c._point, c._normal));
-                Coord3d local_coord = new Coord3d(this._point, l._dir, this._normal.Cross(l._dir));
-                Point3d p = l._point.ConvertTo(local_coord);
+                Coord3d local_coord = new Coord3d(this._point, l.Direction, this._normal.Cross(l.Direction));
+                Point3d p = l.Point.ConvertTo(local_coord);
 
                 if (GeometRi3D.Greater(Abs(p.Y), this.R))
                 {
@@ -1453,7 +1453,7 @@ namespace GeometRi
 
                     // Now check if segment (p1,p2) intrsects circle "c"
                     // Use local coord with center in c.Point and X-axis aligned with segment
-                    local_coord = new Coord3d(c._point, l._dir, c._normal.Cross(l._dir));
+                    local_coord = new Coord3d(c._point, l.Direction, c._normal.Cross(l.Direction));
                     p1 = p1.ConvertTo(local_coord);
                     p2 = p2.ConvertTo(local_coord);
 
@@ -1580,16 +1580,16 @@ namespace GeometRi
             //====================================================
 
 
-            if (l._dir.IsOrthogonalTo(this._normal))
+            if (l.Direction.IsOrthogonalTo(this._normal))
             {
-                if (l._point.BelongsTo(new Plane3d(this._point, this._normal)))
+                if (l.Point.BelongsTo(new Plane3d(this._point, this._normal)))
                 {
                     // coplanar objects
                     // Find intersection of line and circle (2D)
 
                     // Local coord: X - line direction, Z - circle normal
-                    Coord3d local_coord = new Coord3d(this._point, l._dir, this._normal.Cross(l._dir));
-                    Point3d p = l._point.ConvertTo(local_coord);
+                    Coord3d local_coord = new Coord3d(this._point, l.Direction, this._normal.Cross(l.Direction));
+                    Point3d p = l.Point.ConvertTo(local_coord);
 
                     double c = p.Y;
 
@@ -1758,8 +1758,8 @@ namespace GeometRi
             else
             {
                 Line3d l = (Line3d)s.IntersectionWith(new Plane3d(this._point, this._normal));
-                Coord3d local_coord = new Coord3d(this._point, l._dir, this._normal.Cross(l._dir));
-                Point3d p = l._point.ConvertTo(local_coord);
+                Coord3d local_coord = new Coord3d(this._point, l.Direction, this._normal.Cross(l.Direction));
+                Point3d p = l.Point.ConvertTo(local_coord);
 
                 if (GeometRi3D.Greater(Abs(p.Y), this.R))
                 {

--- a/GeometRi/Circle3D.cs
+++ b/GeometRi/Circle3D.cs
@@ -1042,7 +1042,7 @@ namespace GeometRi
         /// <param name="point_on_segment">Closest point on segment</param>
         public double DistanceTo(Segment3d s, out Point3d point_on_circle, out Point3d point_on_segment)
         {
-            Line3d l = s.ToLine;
+            Line3d l = s.Line;
             Plane3d plane = this.ToPlane;
             if (l.IsNotParallelTo(plane._normal))
             {
@@ -1654,7 +1654,7 @@ namespace GeometRi
             }
             //====================================================
 
-            object obj = this.IntersectionWith(s.ToLine);
+            object obj = this.IntersectionWith(s.Line);
 
             if (obj == null)
             {

--- a/GeometRi/Circle3D.cs
+++ b/GeometRi/Circle3D.cs
@@ -1279,7 +1279,7 @@ namespace GeometRi
         /// <param name="point_on_triangle">Closest point on triangle</param>
         public double DistanceTo(Triangle t, out Point3d point_on_circle, out Point3d point_on_triangle)
         {
-            double dist = this.DistanceTo(t.ToPlane, out point_on_circle, out point_on_triangle);
+            double dist = this.DistanceTo(t.Plane, out point_on_circle, out point_on_triangle);
             if (t.DistanceTo(point_on_triangle) <= GeometRi3D.DefaultTolerance)
             {
                 return dist;
@@ -1497,7 +1497,7 @@ namespace GeometRi
         /// </summary>
         public bool Intersects(Triangle t)
         {
-            Plane3d t_plane = t.ToPlane;
+            Plane3d t_plane = t.Plane;
             if (this.DistanceTo(t_plane) > 0) return false;
 
             if (this.IsCoplanarTo(t))

--- a/GeometRi/Circle3D.cs
+++ b/GeometRi/Circle3D.cs
@@ -1502,16 +1502,15 @@ namespace GeometRi
 
             if (this.IsCoplanarTo(t))
             {
-                if (t._a.DistanceTo(this._point) <= this._r) return true;
-                if (t._b.DistanceTo(this._point) <= this._r) return true;
-                if (t._c.DistanceTo(this._point) <= this._r) return true;
+                if (t.A.DistanceTo(this._point) <= this._r) return true;
+                if (t.B.DistanceTo(this._point) <= this._r) return true;
+                if (t.C.DistanceTo(this._point) <= this._r) return true;
 
                 if (this._point.BelongsTo(t)) return true;
-                if (this.IntersectionWith(new Segment3d(t._a, t._b)) != null) return true;
-                if (this.IntersectionWith(new Segment3d(t._b, t._c)) != null) return true;
-                if (this.IntersectionWith(new Segment3d(t._c, t._a)) != null) return true;
+                if (this.IntersectionWith(new Segment3d(t.A, t.B)) != null) return true;
+                if (this.IntersectionWith(new Segment3d(t.B, t.C)) != null) return true;
+                if (this.IntersectionWith(new Segment3d(t.C, t.A)) != null) return true;
             }
-
             object obj = this.IntersectionWith(t_plane);
             if (obj != null && obj.GetType() == typeof(Point3d))
             {

--- a/GeometRi/Coord3D.cs
+++ b/GeometRi/Coord3D.cs
@@ -325,7 +325,7 @@ namespace GeometRi
 
         // Operators overloads
         //-----------------------------------------------------------------
-        public static bool operator ==(Coord3d c1, Coord3d c2)
+     /*   public static bool operator ==(Coord3d c1, Coord3d c2)
         {
 
             if ((object)c1 != null)
@@ -356,6 +356,7 @@ namespace GeometRi
                 return true;
             }
         }
+     */
 
     }
 }

--- a/GeometRi/Ellipse.cs
+++ b/GeometRi/Ellipse.cs
@@ -482,7 +482,7 @@ namespace GeometRi
             }
             //====================================================
 
-            object obj = this.IntersectionWith(s.ToLine);
+            object obj = this.IntersectionWith(s.Line);
 
             if (obj == null)
             {

--- a/GeometRi/Ellipsoid.cs
+++ b/GeometRi/Ellipsoid.cs
@@ -351,7 +351,7 @@ namespace GeometRi
             }
             //====================================================
 
-            object obj = this.IntersectionWith(s.ToLine);
+            object obj = this.IntersectionWith(s.Line);
 
             if (obj == null)
             {

--- a/GeometRi/GeometRi3D.cs
+++ b/GeometRi/GeometRi3D.cs
@@ -272,9 +272,10 @@ namespace GeometRi
 
         static internal bool _coplanar(IPlanarObject obj1, IPlanarObject obj2)
         {
+            Plane3d plane1 = obj1 is PlanarFiniteObject pl1 ? pl1.Plane : obj1 is Plane3d p1? p1 : obj1.ToPlane;
+            Plane3d plane2 = obj2 is PlanarFiniteObject pl2 ? pl2.Plane : obj2 is Plane3d p2? p2 : obj2.ToPlane;
 
-            return obj1.ToPlane.Equals(obj2.ToPlane);
-
+            return plane1.Equals(plane2);
         }
 
         static internal bool _coplanar(ILinearObject obj1, ILinearObject obj2)
@@ -288,7 +289,9 @@ namespace GeometRi
 
         static internal bool _coplanar(IPlanarObject obj1, ILinearObject obj2)
         {
-            return obj1.Normal.IsOrthogonalTo(obj2.Direction) && obj2.ToLine.Point.BelongsTo(obj1.ToPlane);
+            Plane3d plane1 = obj1 is PlanarFiniteObject pl1 ? pl1.Plane : obj1 is Plane3d p1? p1 : obj1.ToPlane;
+
+            return obj1.Normal.IsOrthogonalTo(obj2.Direction) && obj2.ToLine.Point.BelongsTo(plane1);
         }
 
         static internal bool _coplanar(ILinearObject obj1, IPlanarObject obj2)

--- a/GeometRi/GeometRi3D.cs
+++ b/GeometRi/GeometRi3D.cs
@@ -280,11 +280,13 @@ namespace GeometRi
 
         static internal bool _coplanar(ILinearObject obj1, ILinearObject obj2)
         {
-            if (obj1.ToLine.IsParallelTo(obj2.ToLine))
+            Line3d l1 = obj1 is LinearFiniteObject lin1 ? lin1.Line : obj1 is Line3d ? (Line3d)obj1 : obj1.ToLine;
+            Line3d l2 = obj2 is LinearFiniteObject lin2 ? lin2.Line : obj2 is Line3d ? (Line3d)obj2 : obj2.ToLine;
+            if (l1.IsParallelTo(l2))
             {
                 return true;
             }
-            return AlmostEqual(obj1.ToLine.DistanceTo(obj2.ToLine), 0.0);
+            return AlmostEqual(l1.DistanceTo(l2), 0.0);
         }
 
         static internal bool _coplanar(IPlanarObject obj1, ILinearObject obj2)

--- a/GeometRi/Interface.cs
+++ b/GeometRi/Interface.cs
@@ -23,6 +23,7 @@ namespace GeometRi
         Plane3d ToPlane { get; }
     }
 
+
     /// <summary>
     /// Interface for finite objects
     /// </summary>

--- a/GeometRi/Line3D.cs
+++ b/GeometRi/Line3D.cs
@@ -189,10 +189,11 @@ namespace GeometRi
             Vector3d r2 = l.Point.ToVector;
             Vector3d s1 = this.Direction;
             Vector3d s2 = l.Direction;
-            if (s1.Cross(s2).Norm > GeometRi3D.Tolerance)
+            Vector3d s1CrossS2 = s1.Cross(s2);
+            if (s1CrossS2.Norm > GeometRi3D.Tolerance)
             {
                 // Crossing lines
-                return Abs((r2 - r1) * s1.Cross(s2)) / s1.Cross(s2).Norm;
+                return Abs((r2 - r1) * s1CrossS2) / s1CrossS2.Norm;
             }
             else
             {
@@ -231,9 +232,10 @@ namespace GeometRi
             Vector3d r2 = l.Point.ToVector;
             Vector3d s1 = this.Direction;
             Vector3d s2 = l.Direction;
-            if (s1.Cross(s2).Norm > GeometRi3D.Tolerance)
+            Vector3d s1CrossS2 = s1.Cross(s2);
+            if (s1CrossS2.Norm > GeometRi3D.Tolerance)
             {
-                r1 = r2 + (r2 - r1) * s1.Cross(s1.Cross(s2)) / (s1 * s2.Cross(s1.Cross(s2))) * s2;
+                r1 = r2 + (r2 - r1) * s1.Cross(s1CrossS2) / (s1 * s2.Cross(s1CrossS2)) * s2;
                 return r1.ToPoint;
             }
             else

--- a/GeometRi/Line3D.cs
+++ b/GeometRi/Line3D.cs
@@ -12,8 +12,10 @@ namespace GeometRi
     public class Line3d : ILinearObject
     {
 
-        internal Point3d _point;
-        internal Vector3d _dir;
+        private Point3d _point;
+        private Vector3d _dir;
+
+        internal bool HasChanged => _point.HasChanged || _dir.HasChanged;
 
         #region "Constructors"
         /// <summary>
@@ -61,7 +63,7 @@ namespace GeometRi
         /// </summary>
         public Point3d Point
         {
-            get { return _point.Copy(); }
+            get { return _point; }
             set { _point = value.Copy(); }
         }
 
@@ -70,7 +72,7 @@ namespace GeometRi
         /// </summary>
         public Vector3d Direction
         {
-            get { return _dir.Copy(); }
+            get { return _dir; }
             set { _dir = value.Copy(); }
         }
 
@@ -80,7 +82,7 @@ namespace GeometRi
         }
 
         /// <summary>
-        /// Returns copy the object
+        /// Returns copy of the object
         /// </summary>
         public Line3d ToLine
         {

--- a/GeometRi/Plane3D.cs
+++ b/GeometRi/Plane3D.cs
@@ -16,11 +16,6 @@ namespace GeometRi
         internal Vector3d _normal;
         private Coord3d _coord;
 
-        private double? _a;
-        private double? _b;
-        private double? _c;
-        private double? _d;
-
         internal bool HasChanged => _point.HasChanged || _normal.HasChanged;
         private void CheckFields()
         {
@@ -34,10 +29,6 @@ namespace GeometRi
         }
         private void ClearCache()
         {
-            _a = null;
-            _b = null;
-            _c = null;
-            _d = null;
         }
 
         #region "Constructors"
@@ -158,51 +149,18 @@ namespace GeometRi
         /// <summary>
         /// Coefficient A in the general plane equation
         /// </summary>
-        public double A
-        {
-            get
-            {
-                CheckFields();
-                if (_a == null)
-                {
-                    _a = _normal.ConvertTo(_coord).X;
-                }
-                return _a.Value;
-            }
-        }
+        public double A => Normal.ConvertTo(_coord).X;
 
         /// <summary>
         /// Coefficient B in the general plane equation
         /// </summary>
-        public double B
-        {
-            get
-            {
-                CheckFields();
-                if (_b == null)
-                {
-                    _b = _normal.ConvertTo(_coord).Y;
-                }
-
-                return _b.Value;
-            }
-        }
+        public double B => Normal.ConvertTo(_coord).Y;
+      
 
         /// <summary>
         /// Coefficient C in the general plane equation
         /// </summary>
-        public double C
-        {
-            get
-            {
-                CheckFields();
-                if (_c == null)
-                {
-                    _c = _normal.ConvertTo(_coord).Z;
-                }
-                return _c.Value;
-            }
-        }
+        public double C => Normal.ConvertTo(_coord).Z;
 
         /// <summary>
         /// Coefficient D in the general plane equation
@@ -211,16 +169,11 @@ namespace GeometRi
         {
             get
             {
-                CheckFields();
-                if (_d == null)
-                {
                     Point3d p = _point.ConvertTo(_coord);
                     Vector3d v = _normal.ConvertTo(_coord);
-                    _d = -v.X * p.X - v.Y * p.Y - v.Z * p.Z;
+                    return -v.X * p.X - v.Y * p.Y - v.Z * p.Z;
                 }
-
-                return _d.Value;
-            }
+           
         }
 
         /// <summary>

--- a/GeometRi/Plane3D.cs
+++ b/GeometRi/Plane3D.cs
@@ -169,6 +169,11 @@ namespace GeometRi
         }
 
         /// <summary>
+        /// Return this object
+        /// </summary>
+        public Plane3d Plane => this;
+
+        /// <summary>
         /// Returns copy of the object
         /// </summary>
         public Plane3d ToPlane

--- a/GeometRi/Plane3D.cs
+++ b/GeometRi/Plane3D.cs
@@ -16,6 +16,30 @@ namespace GeometRi
         internal Vector3d _normal;
         private Coord3d _coord;
 
+        private double? _a;
+        private double? _b;
+        private double? _c;
+        private double? _d;
+
+        internal bool HasChanged => _point.HasChanged || _normal.HasChanged;
+        private void CheckFields()
+        {
+            if (HasChanged)
+            {
+                _point = _point.Copy();
+                _normal = _normal.Copy();
+
+                ClearCache();
+            }
+        }
+        private void ClearCache()
+        {
+            _a = null;
+            _b = null;
+            _c = null;
+            _d = null;
+        }
+
         #region "Constructors"
         /// <summary>
         /// Default constructor, initializes XY plane in global cordinate system.
@@ -136,7 +160,15 @@ namespace GeometRi
         /// </summary>
         public double A
         {
-            get { return _normal.ConvertTo(_coord).X; }
+            get
+            {
+                CheckFields();
+                if (_a == null)
+                {
+                    _a = _normal.ConvertTo(_coord).X;
+                }
+                return _a.Value;
+            }
         }
 
         /// <summary>
@@ -144,7 +176,16 @@ namespace GeometRi
         /// </summary>
         public double B
         {
-            get { return _normal.ConvertTo(_coord).Y; }
+            get
+            {
+                CheckFields();
+                if (_b == null)
+                {
+                    _b = _normal.ConvertTo(_coord).Y;
+                }
+
+                return _b.Value;
+            }
         }
 
         /// <summary>
@@ -152,7 +193,15 @@ namespace GeometRi
         /// </summary>
         public double C
         {
-            get { return _normal.ConvertTo(_coord).Z; }
+            get
+            {
+                CheckFields();
+                if (_c == null)
+                {
+                    _c = _normal.ConvertTo(_coord).Z;
+                }
+                return _c.Value;
+            }
         }
 
         /// <summary>
@@ -162,16 +211,17 @@ namespace GeometRi
         {
             get
             {
-                Point3d p = _point.ConvertTo(_coord);
-                Vector3d v = _normal.ConvertTo(_coord);
-                return -v.X * p.X - v.Y * p.Y - v.Z * p.Z;
+                CheckFields();
+                if (_d == null)
+                {
+                    Point3d p = _point.ConvertTo(_coord);
+                    Vector3d v = _normal.ConvertTo(_coord);
+                    _d = -v.X * p.X - v.Y * p.Y - v.Z * p.Z;
+                }
+
+                return _d.Value;
             }
         }
-
-        /// <summary>
-        /// Return this object
-        /// </summary>
-        public Plane3d Plane => this;
 
         /// <summary>
         /// Returns copy of the object

--- a/GeometRi/Point3D.cs
+++ b/GeometRi/Point3D.cs
@@ -254,7 +254,7 @@ namespace GeometRi
         /// </summary>
         public double DistanceTo(Segment3d s)
         {
-            Point3d projection = this.ProjectionTo(s.ToLine);
+            Point3d projection = this.ProjectionTo(s.Line);
             if (s._AxialPointLocation(projection) > 0)
             {
                 return this.DistanceTo(projection);

--- a/GeometRi/Point3D.cs
+++ b/GeometRi/Point3D.cs
@@ -222,8 +222,8 @@ namespace GeometRi
         /// <returns></returns>
         public double DistanceTo(Line3d l)
         {
-            Vector3d v = new Vector3d(this, l._point);
-            return v.Cross(l._dir).Norm / l._dir.Norm;
+            Vector3d v = new Vector3d(this, l.Point);
+            return v.Cross(l.Direction).Norm / l.Direction.Norm;
         }
 
         /// <summary>

--- a/GeometRi/Point3D.cs
+++ b/GeometRi/Point3D.cs
@@ -65,13 +65,15 @@ namespace GeometRi
             return new Point3d(_x,_y,_z,_coord);
         }
 
+        internal bool HasChanged { get; private set; }
+
         /// <summary>
         /// X coordinate in reference coordinate system
         /// </summary>
         public double X
         {
             get { return _x; }
-            set { _x = value; }
+            set { _x = value; HasChanged = true; }
         }
         /// <summary>
         /// Y coordinate in reference coordinate system
@@ -79,7 +81,7 @@ namespace GeometRi
         public double Y
         {
             get { return _y; }
-            set { _y = value; }
+            set { _y = value; HasChanged = true;}
         }
         /// <summary>
         /// Z coordinate in reference coordinate system
@@ -87,7 +89,7 @@ namespace GeometRi
         public double Z
         {
             get { return _z; }
-            set { _z = value; }
+            set { _z = value; HasChanged = true;}
         }
 
         /// <summary>
@@ -598,21 +600,19 @@ namespace GeometRi
 
             if (GeometRi3D.UseAbsoluteTolerance)
             {
-                return this.DistanceTo(p) < GeometRi3D.Tolerance;
+                return this.DistanceSquared(p) < GeometRi3D.Tolerance * GeometRi3D.Tolerance;
             }
             else
             {
-                if (this.DistanceTo(_coord.Origin) < GeometRi3D.Tolerance)
+                if (this.DistanceSquared(_coord.Origin) < GeometRi3D.Tolerance * GeometRi3D.Tolerance)
                 {
-                    return this.DistanceTo(p) < GeometRi3D.Tolerance;
+                    return this.DistanceSquared(p) < GeometRi3D.Tolerance * GeometRi3D.Tolerance;
                 }
                 else
                 {
-                    return this.DistanceTo(p) < GeometRi3D.Tolerance * this.DistanceTo(_coord.Origin);
+                    return this.DistanceSquared(p) < Math.Pow(GeometRi3D.Tolerance * this.DistanceTo(_coord.Origin), 2);
                 }
             }
-
-
         }
 
         /// <summary>

--- a/GeometRi/Ray3D.cs
+++ b/GeometRi/Ray3D.cs
@@ -14,6 +14,7 @@ namespace GeometRi
 
         private Point3d _point;
         private Vector3d _dir;
+        internal bool HasChanged => _point.HasChanged || _dir.HasChanged;
 
         /// <summary>
         /// Default constructor, initializes ray starting from origin and aligned with X-axis (in global coordinate system).
@@ -47,7 +48,7 @@ namespace GeometRi
         /// <returns></returns>
         public Point3d Point
         {
-            get { return _point.Copy(); }
+            get { return _point; }
             set { _point = value.Copy(); }
         }
 
@@ -57,7 +58,7 @@ namespace GeometRi
         /// <returns></returns>
         public Vector3d Direction
         {
-            get { return _dir.Copy(); }
+            get { return _dir; }
             set { _dir = value.Copy(); }
         }
 

--- a/GeometRi/Segment3D.cs
+++ b/GeometRi/Segment3D.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using static System.Math;
 
 namespace GeometRi

--- a/GeometRi/Segment3D.cs
+++ b/GeometRi/Segment3D.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using static System.Math;
 
 namespace GeometRi
@@ -11,9 +12,30 @@ namespace GeometRi
 #endif
     public class Segment3d : FiniteObject, ILinearObject, IFiniteObject
     {
-
         private Point3d _p1;
         private Point3d _p2;
+
+        private Point3d _center;
+        private double? _length;
+        private Vector3d _dir;
+        private bool HasChanged => _p1.HasChanged || _p2.HasChanged;
+        private void CheckFields()
+        {
+            if (HasChanged)
+            {
+                _p1 = _p1.Copy();
+                _p2 = _p2.Copy();
+
+                ClearCache();
+            }
+        }
+        private void ClearCache()
+        {
+            _center = null;
+            _length = null;
+            _dir = null;
+        }
+
 
         /// <summary>
         /// Initializes line segment using two points.
@@ -34,36 +56,60 @@ namespace GeometRi
 
         public Point3d P1
         {
-            get { return _p1.Copy(); }
-            set { _p1 = value.Copy(); }
+            get { return _p1; }
+            set { _p1 = value.Copy(); ClearCache();}
         }
 
         public Point3d P2
         {
-            get { return _p2.Copy(); }
-            set { _p2 = value.Copy(); }
+            get { return _p2; }
+            set { _p2 = value.Copy(); ClearCache(); }
         }
 
         public Point3d Center
         {
-            get { return (_p1 + _p2) / 2; }
+            get
+            {
+                CheckFields();
+                if (_center == null)
+                {
+                    _center = (_p1 + _p2) / 2;
+                }
+                return _center;
+            }
         }
 
         public double Length
         {
-            get { return _p1.DistanceTo(_p2); }
+            get {
+                CheckFields();
+                if (_length == null)
+                {
+                    _length = _p1.DistanceTo(_p2);
+                }
+                return _length.Value;
+            }
         }
 
+        /// <summary>
+        /// returns a new vector from P1 to P2.
+        /// </summary>
         public Vector3d ToVector
         {
             get { return new Vector3d(_p1, _p2); }
         }
 
+        /// <summary>
+        /// Returns a new ray starting at P1 and directed towards P2.
+        /// </summary>
         public Ray3d ToRay
         {
             get { return new Ray3d(_p1, new Vector3d(_p1, _p2)); }
         }
 
+        /// <summary>
+        /// Returns a new line.
+        /// </summary>
         public Line3d ToLine
         {
             get { return new Line3d(_p1, _p2); }
@@ -75,7 +121,14 @@ namespace GeometRi
         /// <returns></returns>
         public Vector3d Direction
         {
-            get { return this.ToVector.Normalized; }
+            get {
+                CheckFields();
+                if (_dir == null)
+                {
+                    _dir = ToVector.Normalized;
+                }
+                return _dir;
+            }
         }
 
         public bool IsOriented

--- a/GeometRi/Sphere.cs
+++ b/GeometRi/Sphere.cs
@@ -142,9 +142,9 @@ namespace GeometRi
         /// </summary>
         public double DistanceTo(Segment3d s)
         {
-            if (this._point.ProjectionTo(s.ToLine).BelongsTo(s))
+            if (this._point.ProjectionTo(s.Line).BelongsTo(s))
             {
-                return this.DistanceTo(s.ToLine);
+                return this.DistanceTo(s.Line);
             }
             else
             {
@@ -400,7 +400,7 @@ namespace GeometRi
             }
             //====================================================
 
-            object obj = this.IntersectionWith(s.ToLine);
+            object obj = this.IntersectionWith(s.Line);
 
             if (obj == null)
             {

--- a/GeometRi/Triangle.cs
+++ b/GeometRi/Triangle.cs
@@ -378,7 +378,7 @@ namespace GeometRi
         /// </summary>
         public Point3d Incenter
         {
-            get { return Bisector_A.ToLine.PerpendicularTo(Bisector_B.ToLine); }
+            get { return Bisector_A.Line.PerpendicularTo(Bisector_B.Line); }
         }
 
         /// <summary>
@@ -394,7 +394,7 @@ namespace GeometRi
         /// </summary>
         public Point3d Orthocenter
         {
-            get { return Altitude_A.ToLine.PerpendicularTo(Altitude_B.ToLine); }
+            get { return Altitude_A.Line.PerpendicularTo(Altitude_B.Line); }
         }
 
         /// <summary>
@@ -412,7 +412,7 @@ namespace GeometRi
         {
             get
             {
-                Point3d p = Bisector_A.ToLine.PerpendicularTo(Bisector_B.ToLine);
+                Point3d p = Bisector_A.Line.PerpendicularTo(Bisector_B.Line);
                 double r = 2 * Area / Perimeter;
                 Vector3d v = new Vector3d(_a, _b).Cross(new Vector3d(_a, _c));
                 return new Circle3d(p, r, v);
@@ -1301,8 +1301,8 @@ namespace GeometRi
         internal object _coplanar_IntersectionWith(Line3d l)
         {
             // Check intersection with first two sides
-            Point3d onAB = l.PerpendicularTo(new Segment3d(_a, _b).ToLine);
-            Point3d onBC = l.PerpendicularTo(new Segment3d(_b, _c).ToLine);
+            Point3d onAB = l.PerpendicularTo(new Segment3d(_a, _b).Line);
+            Point3d onBC = l.PerpendicularTo(new Segment3d(_b, _c).Line);
             if (onAB != null && onBC != null)
             {
                 double pos_onAB = new Vector3d(_a, onAB).Dot(new Vector3d(_a, _b)) / (AB * AB);
@@ -1321,7 +1321,7 @@ namespace GeometRi
             }
 
             //Check intersection with third side
-            Point3d onAC = l.PerpendicularTo(new Segment3d(_a, _c).ToLine);
+            Point3d onAC = l.PerpendicularTo(new Segment3d(_a, _c).Line);
             if (onAB != null && onAC != null)
             {
                 double pos_onAB = new Vector3d(_a, onAB).Dot(new Vector3d(_a, _b)) / (AB * AB);
@@ -1380,7 +1380,7 @@ namespace GeometRi
             }
             //====================================================
 
-            object obj = this.IntersectionWith(s.ToLine);
+            object obj = this.IntersectionWith(s.Line);
 
             if (obj == null)
             {

--- a/GeometRi/Triangle.cs
+++ b/GeometRi/Triangle.cs
@@ -11,11 +11,37 @@ namespace GeometRi
 #endif
     public class Triangle : FiniteObject, IPlanarObject
     {
+        private Point3d _a, _b, _c;
+        private double? _ab, _ac, _bc, _perimeter, _area;
+        private Vector3d _normal;
+        private Circle3d _circumcircle;
+        private double? _angleA, _angleB, _angleC;
 
-        internal Point3d _a;
-        internal Point3d _b;
-        internal Point3d _c;
-
+        private bool HasChanged => _a.HasChanged || _b.HasChanged || _c.HasChanged;
+        private void CheckFields()
+        {
+            if (HasChanged)
+            {
+                _a = _a.Copy();
+                _b = _b.Copy();
+                _c = _c.Copy();
+                ClearCache();
+            }
+        }
+        private void ClearCache()
+        {
+            _ab = null;
+            _ac = null;
+            _bc = null;
+            _perimeter = null;
+            _area = null;
+            _normal = null;
+            _circumcircle = null;
+            _angleA = null;
+            _angleB = null;
+            _angleC = null;
+        }
+  
         /// <summary>
         /// Initializes triangle object using three points.
         /// </summary>
@@ -44,7 +70,7 @@ namespace GeometRi
         /// </summary>
         public Point3d A
         {
-            get { return _a.Copy(); }
+            get { return _a; }
             set
             {
                 if (Point3d.CollinearPoints(value, _b, _c))
@@ -52,6 +78,7 @@ namespace GeometRi
                     throw new Exception("Collinear points");
                 }
                 _a = value.Copy();
+                ClearCache();
             }
         }
 
@@ -60,7 +87,7 @@ namespace GeometRi
         /// </summary>
         public Point3d B
         {
-            get { return _b.Copy(); }
+            get { return _b; }
             set
             {
                 if (Point3d.CollinearPoints(_a, value, _c))
@@ -68,6 +95,7 @@ namespace GeometRi
                     throw new Exception("Collinear points");
                 }
                 _b = value.Copy();
+                ClearCache();
             }
         }
 
@@ -76,7 +104,7 @@ namespace GeometRi
         /// </summary>
         public Point3d C
         {
-            get { return _c.Copy(); }
+            get { return _c; }
             set
             {
                 if (Point3d.CollinearPoints(_a, _b, value))
@@ -84,6 +112,7 @@ namespace GeometRi
                     throw new Exception("Collinear points");
                 }
                 _c = value.Copy();
+                ClearCache();
             }
         }
 
@@ -92,7 +121,14 @@ namespace GeometRi
         /// </summary>
         public double AB
         {
-            get { return _a.DistanceTo(_b); }
+            get {
+                CheckFields();
+                if (_ab == null)
+                {
+                    _ab = _a.DistanceTo(_b);
+                }
+                return _ab.Value;
+            }
         }
 
         /// <summary>
@@ -100,7 +136,14 @@ namespace GeometRi
         /// </summary>
         public double AC
         {
-            get { return _a.DistanceTo(_c); }
+            get {
+                CheckFields();
+                if (_ac == null)
+                {
+                    _ac = _a.DistanceTo(_c);
+                }
+                return _ac.Value;
+            }
         }
 
         /// <summary>
@@ -108,7 +151,14 @@ namespace GeometRi
         /// </summary>
         public double BC
         {
-            get { return _b.DistanceTo(_c); }
+            get {
+                CheckFields();
+                if (_bc == null)
+                {
+                    _bc = _b.DistanceTo(_c);
+                }
+                return _bc.Value;
+            }
         }
 
         /// <summary>
@@ -116,7 +166,14 @@ namespace GeometRi
         /// </summary>
         public double Perimeter
         {
-            get { return AB + BC + AC; }
+            get {
+                CheckFields();
+                if (_perimeter == null)
+                {
+                    _perimeter = AB + BC + AC;
+                }
+                return _perimeter.Value;
+            }
         }
 
         /// <summary>
@@ -126,15 +183,27 @@ namespace GeometRi
         {
             get
             {
-                Vector3d v1 = new Vector3d(_a, _b);
-                Vector3d v2 = new Vector3d(_a, _c);
-                return 0.5 * v1.Cross(v2).Norm;
+                CheckFields();
+                if (_area == null)
+                {
+                    // Using Heron's formula
+                    double s = Perimeter / 2;
+                    _area = Sqrt(s * (s - AB) * (s - AC) * (s - BC));
+                }
+                return _area.Value;
             }
         }
 
         public Vector3d Normal
         {
-            get { return new Vector3d(_a, _b).Cross(new Vector3d(_a, _c)).Normalized; }
+            get {
+                CheckFields();
+                if (_normal == null)
+                {
+                    _normal = new Vector3d(_a, _b).Cross(new Vector3d(_a, _c)).Normalized;
+                }
+                return _normal;
+             }
         }
 
         public bool IsOriented
@@ -143,7 +212,7 @@ namespace GeometRi
         }
 
         /// <summary>
-        /// Convert triangle to plane object.
+        /// Convert triangle to a new plane object.
         /// </summary>
         public Plane3d ToPlane
         {
@@ -158,7 +227,14 @@ namespace GeometRi
         /// </summary>
         public Circle3d Circumcircle
         {
-            get { return new Circle3d(_a, _b, _c); }
+            get {
+                CheckFields();
+                if (_circumcircle == null)
+                {
+                    _circumcircle = new Circle3d(_a, _b, _c);
+                }
+                return _circumcircle;
+            }
         }
 
         /// <summary>
@@ -166,7 +242,14 @@ namespace GeometRi
         /// </summary>
         public double Angle_A
         {
-            get { return new Vector3d(_a, _b).AngleTo(new Vector3d(_a, _c)); }
+            get {
+                CheckFields();
+                if (_angleA == null)
+                {
+                    _angleA = new Vector3d(_a, _b).AngleTo(new Vector3d(_a, _c));
+                }
+                return _angleA.Value;
+            }
         }
 
         /// <summary>
@@ -174,7 +257,14 @@ namespace GeometRi
         /// </summary>
         public double Angle_B
         {
-            get { return new Vector3d(_b, _a).AngleTo(new Vector3d(_b, _c)); }
+            get {
+                CheckFields();
+                if (_angleB == null)
+                {
+                    _angleB = new Vector3d(_b, _a).AngleTo(new Vector3d(_b, _c));
+                }
+                return _angleB.Value;
+            }
         }
 
         /// <summary>
@@ -182,7 +272,14 @@ namespace GeometRi
         /// </summary>
         public double Angle_C
         {
-            get { return new Vector3d(_c, _a).AngleTo(new Vector3d(_c, _b)); }
+            get {
+                CheckFields();
+                if (_angleC == null)
+                {
+                    _angleC = new Vector3d(_c, _a).AngleTo(new Vector3d(_c, _b));
+                }
+                return _angleC.Value;
+            }
         }
 
         /// <summary>

--- a/GeometRi/Vector3D.cs
+++ b/GeometRi/Vector3D.cs
@@ -14,6 +14,7 @@ namespace GeometRi
 
         private double[] val;
         internal Coord3d _coord;
+        internal bool HasChanged { get; private set; }
 
         #region "Constructors"
         /// <summary>
@@ -128,7 +129,7 @@ namespace GeometRi
         public double X
         {
             get { return val[0]; }
-            set { val[0] = value; }
+            set { val[0] = value; HasChanged = true; }
         }
 
         /// <summary>
@@ -137,7 +138,7 @@ namespace GeometRi
         public double Y
         {
             get { return val[1]; }
-            set { val[1] = value; }
+            set { val[1] = value;  HasChanged = true;}
         }
 
         /// <summary>
@@ -146,7 +147,7 @@ namespace GeometRi
         public double Z
         {
             get { return val[2]; }
-            set { val[2] = value; }
+            set { val[2] = value;  HasChanged = true;}
         }
 
         /// <summary>

--- a/GeometRi/Vector3D.cs
+++ b/GeometRi/Vector3D.cs
@@ -14,7 +14,25 @@ namespace GeometRi
 
         private double[] val;
         internal Coord3d _coord;
+        private double? _norm;
+        private Vector3d _normalized;
+
         internal bool HasChanged { get; private set; }
+       private void CheckFields()
+        {
+            if (HasChanged)
+            {
+                HasChanged = false;
+                ClearCache();
+            }
+        }
+        private void ClearCache()
+        {
+            _norm = null;
+            _normalized = null;
+        }
+  
+
 
         #region "Constructors"
         /// <summary>
@@ -155,7 +173,15 @@ namespace GeometRi
         /// </summary>
         public double Norm
         {
-            get { return Sqrt(val[0]*val[0] + val[1]*val[1] + val[2]*val[2]); }
+            get
+            {
+                CheckFields();
+                if (_norm == null)
+                {
+                    _norm = Sqrt(val[0] * val[0] + val[1] * val[1] + val[2] * val[2]);
+                }
+                return _norm.Value;
+            }
         }
 
         /// <summary>
@@ -279,12 +305,13 @@ namespace GeometRi
         {
             get
             {
-                Vector3d tmp = this.Copy();
-                double tmp_norm = this.Norm;
-                tmp[0] = val[0] / tmp_norm;
-                tmp[1] = val[1] / tmp_norm;
-                tmp[2] = val[2] / tmp_norm;
-                return tmp;
+                CheckFields();
+                if (_normalized == null)
+                {
+                _normalized = this.Copy();
+                _normalized.Normalize();
+                }
+                return _normalized;
             }
         }
 

--- a/GeometRi/Vector3D.cs
+++ b/GeometRi/Vector3D.cs
@@ -272,7 +272,7 @@ namespace GeometRi
         }
 
         /// <summary>
-        /// Return normalized vector
+        /// Return a new normalized vector
         /// </summary>
         public Vector3d Normalized
         {


### PR DESCRIPTION
This PR embraces a lot of changes, so here is an explaination point by point:

1. All Properties with a `ToObject` syntax are meant to return a new instance. For example, `Triangle3d.ToPlane()` returns a `Copy()` of the triangles plane. 
1.5. For performance purposes, I implemented internal _(for now, we may would like to see it public later)_ equivalent to these `ToObject`, that return a direct cached reference, such as `internal Plane3d Triangle.Plane` vs `public Plane3d Triangle.ToPlane`. these new properties are used in the internal methods when it is relevant.
Nota: I had to intoduce new abstract classes LinearFiniteObject and PlanarFiniteObject, as I did not implement for now these changes for all the library (I focused on the primary objects, such as point, segment, plane, triangle)

2. The properties that come from the constructor (i.e. `Ploint3d.X`) are not duplicated anymore by the getter. For example:

``` c#
public Point3d P1
{
            get { return _p1.Copy(); }
            set { _p1 = value.Copy(); }
}
```
becomes: (I will explain later the ClearCache() method)
```c#
public Point3d P1
{
            get { return _p1; }
            set { _p1 = value.Copy(); ClearCache();
}
```

3. the other properties, that were each time evaluated by the getter, such as Vector3d.Norm _(time consuming due to the sqrt())_ are now calulated once, stored in a private cache field, and then returned:

    
```c#
    public double Norm
        {
            get { return Sqrt(val[0]*val[0] + val[1]*val[1] + val[2]*val[2]); }
         }

```
becomes
```c#
    public double Norm
        {
            get
            {
                CheckFields();
                if (_norm == null)
                {
                    _norm = Sqrt(val[0] * val[0] + val[1] * val[1] + val[2] * val[2]);
                }
                return _norm.Value;
            }
        }
```

This cache increases drastically the performances. HOWEVER, as we now have a direct access to the field references, (cf. point 2.), we have to make sure that the cache is always valid.
This is why I introduced a `.HasChanged`  property, that is set to true as soon as some property has been manually modified.

So if you take a look to the commit changes, you will see a `ClearCache()` method that is called as soon as a field is manually set, and a `CheckField()` method that checks if one of this fields contents has been changed. If so, it also calls `ClearCache()`.

4. I also commented out the uncessessary override of the Coord3d `==` operator. It saved me alone 5s on running time (see 6.). Surprisingly, it is the major optimzation here.

5. All unit tests still pass !

6. in term of performances, I run a personal heavy implementation of the library (a lot of distances and intersection checks). The mean running time decreases from approx 34s to 24s ! Therefore, the optimization is for now a sucess.

7. in another PR, I will implement the Môller-Trumbore triangle-ray intersection. I just chose not to mess with this PR to separate topics. FYI : it works flawesly with again, performance improvment. In general, there is still some work to do for this "interection topics", with optimizations here and there.